### PR TITLE
feat: add rate limiting and cache headers

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -26,6 +26,7 @@ from core.exception_handlers import (
     validation_exception_handler,
     general_exception_handler,
 )
+from middleware.rate_limit import RateLimitMiddleware
 from routes import ingredients, recipes, ratings, units, tags, auth, admin, user_ingredients, stats, analytics
 from routes.tags import recipe_tags_router
 
@@ -78,7 +79,9 @@ app = FastAPI(
     redoc_url="/redoc",
 )
 
-# Add CORS middleware
+# Rate limiting first, then CORS wraps outermost (last registered = outermost).
+# This ensures 429 responses still get CORS headers.
+app.add_middleware(RateLimitMiddleware)
 app.add_middleware(CORSHeaderMiddleware)
 
 # Add exception handlers

--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -1,0 +1,99 @@
+"""Per-IP rate limiting middleware."""
+
+import logging
+import time
+from collections import defaultdict, deque
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger(__name__)
+
+# Paths exempt from rate limiting
+EXEMPT_PATHS = {"/health"}
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Sliding-window per-IP rate limiter.
+
+    All requests are rate-limited equally. OPTIONS requests and
+    health checks are exempt. Rate limiting is per-process — with
+    multiple uvicorn workers, the effective limit per IP is
+    max_requests * num_workers.
+    """
+
+    CLEANUP_INTERVAL = 100  # Purge stale IPs every N requests
+    _instances: list["RateLimitMiddleware"] = []
+
+    def __init__(self, app, max_requests: int = 60, window_seconds: int = 60):
+        super().__init__(app)
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._requests: dict[str, deque] = defaultdict(deque)
+        self._request_count = 0
+        RateLimitMiddleware._instances.append(self)
+
+    def reset(self):
+        """Clear all rate limit state. Used by test fixtures."""
+        self._requests.clear()
+        self._request_count = 0
+
+    @classmethod
+    def reset_all(cls):
+        """Reset all middleware instances. Used by test fixtures."""
+        for instance in cls._instances:
+            instance.reset()
+
+    def _get_client_ip(self, request: Request) -> str:
+        """Client IP from X-Real-IP (set by Caddy) or direct connection."""
+        return (
+            request.headers.get("x-real-ip")
+            or (request.client.host if request.client else "unknown")
+        )
+
+    def _cleanup_stale(self, now: float):
+        """Remove IPs with no recent requests to prevent memory growth."""
+        cutoff = now - self.window_seconds
+        stale = [ip for ip, ts in self._requests.items() if not ts or ts[-1] < cutoff]
+        for ip in stale:
+            del self._requests[ip]
+
+    async def dispatch(self, request: Request, call_next):
+        # Exempt OPTIONS (CORS preflight) and health checks
+        if request.method == "OPTIONS" or request.url.path in EXEMPT_PATHS:
+            return await call_next(request)
+
+        client_ip = self._get_client_ip(request)
+        now = time.monotonic()
+
+        # Periodic cleanup
+        self._request_count += 1
+        if self._request_count % self.CLEANUP_INTERVAL == 0:
+            self._cleanup_stale(now)
+
+        # Trim timestamps outside the window
+        timestamps = self._requests[client_ip]
+        cutoff = now - self.window_seconds
+        while timestamps and timestamps[0] < cutoff:
+            timestamps.popleft()
+
+        # Reject if over limit
+        if len(timestamps) >= self.max_requests:
+            retry_after = int(self.window_seconds - (now - timestamps[0])) + 1
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Rate limit exceeded. Please slow down."},
+                headers={"Retry-After": str(max(1, retry_after))},
+            )
+
+        # Record request
+        timestamps.append(now)
+
+        # Forward and add rate limit headers to response
+        response = await call_next(request)
+        response.headers["X-RateLimit-Limit"] = str(self.max_requests)
+        response.headers["X-RateLimit-Remaining"] = str(
+            self.max_requests - len(timestamps)
+        )
+        return response

--- a/docs/plans/2026-03-21-rate-limiting-design.md
+++ b/docs/plans/2026-03-21-rate-limiting-design.md
@@ -57,3 +57,13 @@ Implemented as Caddy path matchers and header directives — easy to adjust with
 - DDoS protection (would need Caddy `rate_limit` plugin or AWS WAF)
 - Per-user rate limits for authenticated users (not needed while the only authenticated users are site owners)
 - Rate limiting by API key (no API key system exists; could be added later if the API is monetized or gets heavy use from specific consumers)
+
+## Implementation notes
+
+Used a custom `RateLimitMiddleware` (in `api/middleware/rate_limit.py`) instead of `slowapi`. A custom middleware is simpler (~50 lines), has no new dependency, and matches the existing `CORSHeaderMiddleware` pattern.
+
+Auth exemption was removed from the original design. 60 req/min per IP doesn't affect normal browser use, and checking for a Bearer header without validating the JWT would allow trivial bypass. All requests are rate-limited equally; `OPTIONS` and `/health` are exempt.
+
+Rate limiting is per-worker (in-memory). With 2 uvicorn workers, the effective limit per IP is up to ~120 req/min. This is acceptable for the threat model (preventing instance overload).
+
+Cache headers are only applied to endpoints that return identical responses regardless of authentication (`/stats`, all analytics endpoints, `/units`, `/tags/public`, `/openapi.json`). Endpoints like `/recipes/*` include user-specific fields (`user_rating`, `private_tags`) and must not be cached as `public`.

--- a/infrastructure/ansible/files/Caddyfile.j2
+++ b/infrastructure/ansible/files/Caddyfile.j2
@@ -34,6 +34,25 @@
         try_files {path} /index.html
     }
 
+    # Cache headers for read-only, non-personalized API responses
+    @api_stable {
+        method GET
+        path /api/v1/stats /api/v1/analytics/ingredient-usage /api/v1/analytics/recipe-complexity /api/v1/analytics/cocktail-space /api/v1/analytics/cocktail-space-em /api/v1/analytics/ingredient-tree /api/v1/analytics/recipe-similar /api/v1/analytics/recipe-distances-em/download
+    }
+    header @api_stable Cache-Control "public, max-age=3600"
+
+    @api_public_lists {
+        method GET
+        path /api/v1/units /api/v1/tags/public
+    }
+    header @api_public_lists Cache-Control "public, max-age=300"
+
+    @api_openapi {
+        method GET
+        path /api/v1/openapi.json
+    }
+    header @api_openapi Cache-Control "public, max-age=86400"
+
     header {
         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
         X-Content-Type-Options "nosniff"

--- a/infrastructure/caddy/Caddyfile
+++ b/infrastructure/caddy/Caddyfile
@@ -44,6 +44,25 @@
     @static path *.js *.css *.png *.jpg *.jpeg *.gif *.svg *.woff *.woff2
     header @static Cache-Control "public, max-age=3600"
 
+    # Cache headers for read-only, non-personalized API responses
+    @api_stable {
+        method GET
+        path /api/v1/stats /api/v1/analytics/ingredient-usage /api/v1/analytics/recipe-complexity /api/v1/analytics/cocktail-space /api/v1/analytics/cocktail-space-em /api/v1/analytics/ingredient-tree /api/v1/analytics/recipe-similar /api/v1/analytics/recipe-distances-em/download
+    }
+    header @api_stable Cache-Control "public, max-age=3600"
+
+    @api_public_lists {
+        method GET
+        path /api/v1/units /api/v1/tags/public
+    }
+    header @api_public_lists Cache-Control "public, max-age=300"
+
+    @api_openapi {
+        method GET
+        path /api/v1/openapi.json
+    }
+    header @api_openapi Cache-Control "public, max-age=86400"
+
     # Security headers
     header {
         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,17 @@ def clear_database_cache():
     _reset_database_singleton()
 
 
+@pytest.fixture(scope="function", autouse=True)
+def reset_rate_limiter():
+    """Reset rate limiter state after each test to prevent cross-test 429s"""
+    yield
+    try:
+        from middleware.rate_limit import RateLimitMiddleware
+        RateLimitMiddleware.reset_all()
+    except (ImportError, AttributeError):
+        pass  # Middleware not yet created
+
+
 @pytest.fixture(scope="session")
 def postgres_container():
     """Session-scoped PostgreSQL container - shared across all tests"""

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,95 @@
+"""Tests for rate limiting middleware"""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestRateLimiting:
+    """Test per-IP rate limiting behavior"""
+
+    async def test_requests_under_limit_succeed(self, test_client_memory):
+        """Requests under the rate limit should succeed normally"""
+        response = await test_client_memory.get("/stats")
+        assert response.status_code == 200
+
+    async def test_rate_limit_headers_present(self, test_client_memory):
+        """Responses should include rate limit headers"""
+        response = await test_client_memory.get("/stats")
+        assert "X-RateLimit-Limit" in response.headers
+        assert "X-RateLimit-Remaining" in response.headers
+
+    async def test_rate_limit_remaining_decrements(self, test_client_memory):
+        """X-RateLimit-Remaining should decrement with each request"""
+        r1 = await test_client_memory.get("/stats")
+        r2 = await test_client_memory.get("/stats")
+        remaining1 = int(r1.headers["X-RateLimit-Remaining"])
+        remaining2 = int(r2.headers["X-RateLimit-Remaining"])
+        assert remaining2 == remaining1 - 1
+
+    async def test_returns_429_when_limit_exceeded(self, test_client_memory):
+        """Should return 429 when rate limit is exceeded"""
+        for _ in range(60):
+            await test_client_memory.get("/stats")
+
+        response = await test_client_memory.get("/stats")
+        assert response.status_code == 429
+        assert "Retry-After" in response.headers
+        data = response.json()
+        assert "detail" in data
+
+    async def test_health_endpoint_exempt(self, test_client_memory):
+        """Health check should not be rate limited"""
+        for _ in range(65):
+            response = await test_client_memory.get("/health")
+        assert response.status_code == 200
+
+    async def test_options_request_exempt(self, test_client_memory):
+        """OPTIONS (CORS preflight) should not be rate limited"""
+        for _ in range(65):
+            response = await test_client_memory.options("/stats")
+        assert response.status_code != 429
+
+    async def test_different_ips_have_separate_limits(self, test_client_memory):
+        """Different X-Real-IP values should have independent rate limits"""
+        # Exhaust limit for IP "1.2.3.4"
+        for _ in range(60):
+            await test_client_memory.get("/stats", headers={"X-Real-IP": "1.2.3.4"})
+        # IP "1.2.3.4" should be limited
+        response = await test_client_memory.get(
+            "/stats", headers={"X-Real-IP": "1.2.3.4"}
+        )
+        assert response.status_code == 429
+        # IP "5.6.7.8" should still work
+        response = await test_client_memory.get(
+            "/stats", headers={"X-Real-IP": "5.6.7.8"}
+        )
+        assert response.status_code == 200
+
+
+class TestRateLimitHeaders:
+    """Test rate limit response header values"""
+
+    async def test_limit_header_value(self, test_client_memory):
+        """X-RateLimit-Limit should reflect the configured max"""
+        response = await test_client_memory.get("/stats")
+        assert response.headers["X-RateLimit-Limit"] == "60"
+
+    async def test_429_response_format(self, test_client_memory):
+        """429 response should have correct format"""
+        for _ in range(60):
+            await test_client_memory.get("/stats")
+
+        response = await test_client_memory.get("/stats")
+        assert response.status_code == 429
+        assert int(response.headers["Retry-After"]) > 0
+        assert response.json()["detail"] == "Rate limit exceeded. Please slow down."
+
+    async def test_429_includes_cors_headers(self, test_client_memory):
+        """429 responses should still include CORS headers"""
+        for _ in range(60):
+            await test_client_memory.get("/stats")
+
+        response = await test_client_memory.get("/stats")
+        assert response.status_code == 429
+        assert response.headers.get("Access-Control-Allow-Origin") == "*"


### PR DESCRIPTION
## Summary

- **Per-IP rate limiting middleware** (`api/middleware/rate_limit.py`): Sliding-window rate limiter at 60 req/min per IP using stdlib only. OPTIONS and `/health` exempt. CORS headers preserved on 429 responses.
- **Cache-Control headers** in Caddy for non-personalized API endpoints (`/stats`, analytics, `/units`, `/tags/public`, `/openapi.json`). Personalized endpoints like `/recipes/*` are excluded.
- **10 tests** covering rate limit enforcement, header values, IP isolation, exemptions, and CORS on 429s.

## Design decisions

- Custom middleware instead of `slowapi` — simpler (~50 lines), no new dependency, matches existing `CORSHeaderMiddleware` pattern.
- No auth exemption — 60 req/min won't affect normal use, and checking Bearer without JWT validation allows trivial bypass.
- Per-worker rate limiting (up to ~120 req/min effective with 2 workers) — acceptable for the threat model.

## Test plan

- [x] All 10 rate limiting tests pass
- [x] Full test suite (545 tests) passes — 1 pre-existing flaky test unrelated to this change
- [ ] Validate Caddy config on deploy (Caddy not installed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)